### PR TITLE
add autodecoding of URL Encoded SSB References

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -473,6 +473,7 @@ var inline = {
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
   emoji: noop,
+  urlEncodedMention: /^(\s)?((?:%25|%40|%26)[A-Za-z0-9%]+%3D\.[A-Za-z0-9%]+)/,
   mention: /^(\s)?([@%&][A-Za-z0-9\._\-+=\/]*[A-Za-z0-9_\-+=\/])/,
   hashtag: /^(\s)?(#[^\d ][^\s,.\(\)\[\]"\?!<>'`^]+)/,
   text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n| [@%&#]|$)/
@@ -590,6 +591,17 @@ InlineLexer.prototype.output = function(src) {
       src = src.substring(cap[0].length);
       out += cap[1];
       continue;
+    }
+
+    // url encoded mention
+    if (!this.inLink && this.options.mentions && (cap = this.rules.urlEncodedMention.exec(src))) {
+      src = src.substring(cap[0].length);
+      try {
+        var mention = decodeURIComponent(cap[2])
+      } catch (e) {
+        var mention = cap[2]
+      }
+      out += this.renderer.mention(cap[1], mention)
     }
 
     // mention

--- a/test/tests/ssb_mentions.html
+++ b/test/tests/ssb_mentions.html
@@ -17,3 +17,15 @@
 <p>
   <a href="%rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0=.sha256">%rNQRDI4...</a> [<a href="%rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0=.sha256">%rNQRDI4...</a>]
 </p>
+<p>
+  hello <a href="@bob">@bob</a> and <a href="@hxGxqPrplLjRG2vtjQL87abX4QKqeLgCwQpS730nNwE=.ed25519">@hxGxqPr...</a>
+</p>
+<p>
+  hello <a href="%msg">%msg</a> and <a href="%rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0=.sha256">%rNQRDI4...</a>
+</p>
+<p>
+  hello <a href="&blob">&amp;blob</a> and <a href="&GyBbCYYqnHOQEN2sLnXly/105lHcU3JJAllYLT2vQEI=.sha256">&amp;GyBbCYY...</a>
+</p>
+<p>
+  <a href="%rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0=.sha256">%rNQRDI4...</a> [<a href="%rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0=.sha256">%rNQRDI4...</a>]
+</p>

--- a/test/tests/ssb_mentions.text
+++ b/test/tests/ssb_mentions.text
@@ -11,3 +11,11 @@ this [&blob](http://foo.com) and this [link](&blob)
 @bob @bob @bob
 
 %rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0=.sha256 [%rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0=.sha256]
+
+hello @bob and %40hxGxqPrplLjRG2vtjQL87abX4QKqeLgCwQpS730nNwE%3D.ed25519
+
+hello %msg and %25rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0%3D.sha256
+
+hello &blob and %26GyBbCYYqnHOQEN2sLnXly%2F105lHcU3JJAllYLT2vQEI%3D.sha256
+
+%25rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0%3D.sha256 [%25rNQRDI4mK2jRtVGaBVV3AZ9ReDyBxAYdSXx4k71cHi0%3D.sha256]


### PR DESCRIPTION
This adds a feature discussed in #somebody-should and #ssb-learning. Originally proposed by @mixmix in the following SSB thread: %jeM0nHIH9wzyHwQTlkix2ybPFNflVZRuOM7y8rgTJnE=.sha256

This the simplest / most frictionless way I found to incorporate this feature into ssb's markdown parser. This only covers the basic case where a user pasts a plain text ssbref string (which one expects to auto translate into a link in Patchwork). These ssb links will now get auto-rendered correctly even with url-encoded ssb references entered in by the user.

However, if someone manually puts a url encoded ssb ref in a link it will not be autodecoded (see below)
`Check out this [link](%25jeM0nHIH9wzyHwQTlkix2ybPFNflVZRuOM7y8rgTJnE%3D.sha256)`

I was thinking about handling this use case as well, but in the end decided it was probably better to just cover one main use case, rather than going haywire and auto decoding every possible way of entering url encoded ssb-ref's in a patchwork emssage.

I'm happy to edit this PR to cover more use cases if people think I missed an important one.